### PR TITLE
fix: fixed data fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14116,6 +14116,14 @@
         "react-popper": "^1.3.7"
       }
     },
+    "react-query": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-2.23.0.tgz",
+      "integrity": "sha512-LHBhrr7ntstjpt85ssEaW3cGJx4BqQBFleTM3fXMO0MFzaMDQx0oxdUur+iQSOpLGPlrpToJbrjFNMQTpEExdA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5"
+      }
+    },
     "react-refresh": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-query": "^2.23.0",
     "react-transition-group": "^4.4.1",
     "yup": "^0.29.3"
   },

--- a/src/api/collaborator.ts
+++ b/src/api/collaborator.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+export interface Collaborator {
+  id: number;
+  name: string;
+  username: string;
+  email: string;
+  password: string;
+  imagePath: string;
+  stateUser: 'active' | 'inactive' | 'banned';
+  userDescription: string;
+  activationKey: string;
+  resetKey: string;
+  resetDate: string;
+}
+
+export const getCollaborators = () =>
+  axios.get<Collaborator[]>('https://api.faztcommunity.dev/collaborators').then((res) => res.data);

--- a/src/components/organisms/MapGridUsers/index.tsx
+++ b/src/components/organisms/MapGridUsers/index.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
+
 import styled from '@Styles/styled';
-import axios from 'axios';
 import Image from '@Atoms/Image';
+import { useCollaborators } from '@Hooks/collaborator';
 
 type MapGridUsersProps = {
   width?: string;
@@ -64,30 +65,12 @@ const StyledMapGridUsers = styled.div<MapGridUsersProps>`
 `;
 
 const MapGridUsers: React.FC<MapGridUsersProps> = () => {
-  const initialState = [
-    {
-      id: 0,
-      name: 'Fede',
-      username: 'Fede',
-      email: 'elfedeomg@gmail.com',
-      imagePath: '',
-      userDescription: ''
-    }
-  ];
-
-  const [listUsers, setListUsers] = useState(initialState);
-  useEffect(() => {
-    const getData = async () => {
-      const result = await axios.get('https://api.faztcommunity.dev/collaborators').catch(() => null);
-      setListUsers(result?.data);
-    };
-    getData();
-  }, []);
+  const { data } = useCollaborators();
 
   return (
     <StyledContainer>
       <StyledMapGridUsers>
-        {listUsers.slice(0, 15).map((user) => (
+        {data?.slice(0, 15).map((user) => (
           <Image
             key={user.id}
             variant="round"

--- a/src/hooks/collaborator.ts
+++ b/src/hooks/collaborator.ts
@@ -1,0 +1,7 @@
+import { useQuery } from 'react-query';
+
+import { getCollaborators } from '@Api/collaborator';
+
+export const useCollaborators = () => {
+  return useQuery('collaborators', getCollaborators);
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,15 +1,24 @@
 import React from 'react';
 import { AppProps } from 'next/app';
 import { ThemeProvider } from 'emotion-theming';
+import { ReactQueryCacheProvider, QueryCache } from 'react-query';
+import { Hydrate } from 'react-query/hydration';
+
 import GlobalStyles from '@Styles/GlobalStyles';
 import theme from '@Styles/theme';
 
+const queryCache = new QueryCache();
+
 const App: React.FC<AppProps> = ({ Component, pageProps }) => {
   return (
-    <ThemeProvider theme={theme}>
-      <GlobalStyles />
-      <Component {...pageProps} />
-    </ThemeProvider>
+    <ReactQueryCacheProvider queryCache={queryCache}>
+      <Hydrate state={pageProps.dehydratedState}>
+        <ThemeProvider theme={theme}>
+          <GlobalStyles />
+          <Component {...pageProps} />
+        </ThemeProvider>
+      </Hydrate>
+    </ReactQueryCacheProvider>
   );
 };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,9 @@
 import React from 'react';
+import { GetStaticProps } from 'next';
+import { QueryCache } from 'react-query';
+import { dehydrate } from 'react-query/hydration';
+
+import { getCollaborators } from '@Api/collaborator';
 import MainPage from '@Templates/MainPage';
 import Head from '@Molecules/Head';
 import Welcome from '@Organisms/Welcome';
@@ -24,6 +29,17 @@ const Index: React.FC = () => {
       </MainPage>
     </>
   );
+};
+
+export const getStaticProps: GetStaticProps = async () => {
+  const queryCache = new QueryCache();
+  await queryCache.prefetchQuery('collaborators', getCollaborators);
+
+  return {
+    props: {
+      dehydratedState: dehydrate(queryCache)
+    }
+  };
 };
 
 export default Index;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,9 @@
       "@Organisms/*": ["src/components/organisms/*"],
       "@Templates/*": ["src/components/templates/*"],
       "@Assets/*": ["src/assets/*"],
-      "@Styles/*": ["src/styles/*"]
+      "@Styles/*": ["src/styles/*"],
+      "@Api/*": ["src/api/*"],
+      "@Hooks/*": ["src/hooks/*"]
     },
 
     "target": "es6",


### PR DESCRIPTION
están haciendo un mal uso del data-fetching, andan haciendo client side rendering en vez de generar cosas estáticas o del lado del servidor.
si se fijan en el proyecto antes de este pr, en la pagina de index cuando van a ver el código fuente, las fotos de dano, github, etc no aparecen por ningún lado, eso es porque no se renderizan del servidor
metí react-query porque se hace muy complicado hacer estas cosas si no se usan librerias de este tipo, esta mete las querys del servidor en cache para poder reutilizarlas en cualquier parte del arbol de componentes
les deje un ejemplo de forma estática para el landing, quería hacerlo también en la pagina de contributors pero es imposible logearme, el formulario le falta el input de name.
también quiero dejar en claro que para que también se renderizen las cosas del lado de servidor cuando estén logeados, van a tener que hacer uso de una api interna dentro de next, hay una issue que cerraron donde explica todo eso, si mergean este pr intenten cambiar ahora todos los useEffect con una request por react-query, y deben tener en cuenta que es necesario que en la pagina donde usen esos componentes hacer un prefetchQuery y usar la prop de dehydratedState, de lo contrario no se va a renderizar desde el servidor o de forma estática y va ser exactamente igual que usar axios, que la cosa de usar next no es esa, también van a tener que despedirse del localStorage porque al servidor no llega, reitero en la issue que había armado esta mejor explicado
